### PR TITLE
[RadioButtonGroup]: Fix types for values and selected

### DIFF
--- a/src/components/molecules/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/src/components/molecules/RadioButtonGroup/RadioButtonGroup.tsx
@@ -48,13 +48,13 @@ type DefaultProps = {
 
 type RequiredProps = {
   radioButtons: RadioButtonType[];
-  selected: string;
+  selected: string | number;
   onSelect: (value: string) => void;
 }
 
 
 export type RadioButtonType = {
-  value: string;
+  value: string | number;
   label: React.ReactNode;
   labelClassName?: string;
   parentClassName?: string;


### PR DESCRIPTION
Many components are passing values and selected as "number" while others are passing as "string"